### PR TITLE
Rewrite string(x) to string(rune(x))

### DIFF
--- a/join.go
+++ b/join.go
@@ -80,5 +80,5 @@ func JoinTokens(tokens []string) (string, error) {
 	for _, r := range word {
 		sum += r
 	}
-	return string(sum), nil
+	return string(rune(sum)), nil
 }


### PR DESCRIPTION
go vet에 잘못된 변환에 대한 경고가 추가되었습니다. 이를 반영하기 위해서 코드를 수정하였습니다.
자세한 내용은 아래 링크를 참고해주세요. 
https://go.dev/doc/go1.15#vet